### PR TITLE
Update checkout-frontend-library version to 0.52.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -483,9 +483,9 @@
       "dev": true
     },
     "@boldcommerce/checkout-frontend-library": {
-      "version": "0.51.2",
-      "resolved": "https://registry.npmjs.org/@boldcommerce/checkout-frontend-library/-/checkout-frontend-library-0.51.2.tgz",
-      "integrity": "sha512-ekOLzCupMtWAiHQ1tVcjHPDMMSq0vMcmJdaUpA6mQy1c/GhhmXqgoIzRZ0tawhXCs/+tQw9sGCK0UiiVyKUu/w=="
+      "version": "0.52.1",
+      "resolved": "https://registry.npmjs.org/@boldcommerce/checkout-frontend-library/-/checkout-frontend-library-0.52.1.tgz",
+      "integrity": "sha512-iK3KwKQbWD0XPZJlo0PlUrOtIJ0WFCMUgBJaPx1m0lZ3xqa59qOXOfAofVQUU7QHPRgbfHQYRZ3iR1WFh+MUjA=="
     },
     "@eslint/eslintrc": {
       "version": "0.4.3",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "typescript-transform-paths": "^3.3.1"
   },
   "peerDependencies": {
-    "@boldcommerce/checkout-frontend-library": "0.51.2"
+    "@boldcommerce/checkout-frontend-library": "0.52.1"
   },
   "files": [
     "lib/**/*"
@@ -52,7 +52,7 @@
     "*.{js,jsx,ts,tsx}": "eslint --fix --max-warnings 0"
   },
   "dependencies": {
-    "@boldcommerce/checkout-frontend-library": "0.51.2",
+    "@boldcommerce/checkout-frontend-library": "0.52.1",
     "@paypal/paypal-js": "^7.0.1",
     "@types/applepayjs": "^3.0.4",
     "@types/googlepay": "^0.6.4"


### PR DESCRIPTION
Changes where made to the Checkout Front End Library and Checkout Express Pay Library need to be in sync.