### PR TITLE
PPCP Wallet Pay Shipping Issue

### DIFF
--- a/src/paypal/ppcp_buttons/ppcpOnShippingChange.ts
+++ b/src/paypal/ppcp_buttons/ppcpOnShippingChange.ts
@@ -3,7 +3,7 @@ import {
     IWalletPayOnShippingRequest,
     walletPayOnShipping
 } from '@boldcommerce/checkout-frontend-library';
-import {API_RETRY, displayError,} from 'src';
+import {API_RETRY} from 'src';
 
 
 export async function ppcpOnShippingChange(data: OnShippingChangeData, actions: OnShippingChangeActions): Promise<void> {
@@ -20,7 +20,6 @@ export async function ppcpOnShippingChange(data: OnShippingChangeData, actions: 
 
     const res = await walletPayOnShipping(body, API_RETRY);
     if (!res.success) {
-        displayError('There was an unknown error while getting the shipping details.', 'payment_gateway', 'unknown_error');
         return actions.reject();
     }
 

--- a/tests/paypal/ppcp_buttons/ppcpOnShippingChange.test.ts
+++ b/tests/paypal/ppcp_buttons/ppcpOnShippingChange.test.ts
@@ -5,14 +5,11 @@ import {
     walletPayOnShipping
 } from '@boldcommerce/checkout-frontend-library';
 import {applicationStateMock} from '@boldcommerce/checkout-frontend-library/lib/variables/mocks';
-import {displayError} from 'src';
 import {ppcpOnShippingChange} from 'src/paypal/ppcp_buttons/ppcpOnShippingChange';
 import {OnShippingChangeActions, OnShippingChangeData} from '@paypal/paypal-js/types/components/buttons';
 
 jest.mock('@boldcommerce/checkout-frontend-library/lib/walletPay/walletPayOnShipping');
-jest.mock('src/actions/displayError');
 const walletPayOnShippingMock = mocked(walletPayOnShipping, true);
-const displayErrorMock = mocked(displayError, true);
 
 describe('testing  ppcpOnShippingChange function', () => {
 
@@ -52,7 +49,7 @@ describe('testing  ppcpOnShippingChange function', () => {
 
         await ppcpOnShippingChange(dataMock, actionMock);
         expect(walletPayOnShippingMock).toHaveBeenCalledTimes(1);
-        expect(displayErrorMock).toHaveBeenCalledTimes(0);
+        expect(actionMock.reject).toHaveBeenCalledTimes(0);
     });
 
 
@@ -62,8 +59,7 @@ describe('testing  ppcpOnShippingChange function', () => {
         walletPayOnShippingMock.mockReturnValue(Promise.resolve(paymentReturn));
 
         await ppcpOnShippingChange(dataMock, actionMock);
-        expect(displayErrorMock).toHaveBeenCalledTimes(1);
-        expect(displayErrorMock).toHaveBeenCalledWith('There was an unknown error while getting the shipping details.', 'payment_gateway', 'unknown_error');
+        expect(walletPayOnShippingMock).toHaveBeenCalledTimes(1);
         expect(actionMock.reject).toHaveBeenCalledTimes(1);
     });
 


### PR DESCRIPTION
The process order doesnt work due to flash error message in the state when `on-shipping` endpoint have some error. To fix it we will be removing the flash error message and use `action.reject` to show the error message in the paypal modal. 