### PR TITLE
PXP-2537 Update PPCP apple pay to use tax and shipping estimate calls

### DIFF
--- a/tests/paypal/ppcp_apple/ppcpOnShippingContactSelectedApple.test.ts
+++ b/tests/paypal/ppcp_apple/ppcpOnShippingContactSelectedApple.test.ts
@@ -13,12 +13,16 @@ import {
     getCurrency,
     getShipping,
     getShippingLines,
-    setTaxes
+    setTaxes,
+    estimateTaxes,
+    estimateShippingLines,
+    getOrderInitialData
 } from '@boldcommerce/checkout-frontend-library';
 import {
     addressesMock,
     applicationStateMock,
     currencyMock,
+    orderInitialDataMock,
     shippingMock
 } from '@boldcommerce/checkout-frontend-library/lib/variables/mocks';
 import ApplePayShippingContactSelectedEvent = ApplePayJS.ApplePayShippingContactSelectedEvent;
@@ -31,8 +35,11 @@ jest.mock('src/utils/getPaymentRequestDisplayItems');
 jest.mock('@boldcommerce/checkout-frontend-library/lib/state/getCurrency');
 jest.mock('@boldcommerce/checkout-frontend-library/lib/state/getShipping');
 jest.mock('@boldcommerce/checkout-frontend-library/lib/state/getApplicationState');
+jest.mock('@boldcommerce/checkout-frontend-library/lib/state/getOrderInitialData');
 jest.mock('@boldcommerce/checkout-frontend-library/lib/taxes/setTaxes');
+jest.mock('@boldcommerce/checkout-frontend-library/lib/taxes/estimateTaxes');
 jest.mock('@boldcommerce/checkout-frontend-library/lib/shipping/getShippingLines');
+jest.mock('@boldcommerce/checkout-frontend-library/lib/shipping/estimateShippingLines');
 const getPPCPApplePaySessionCheckedMock = mocked(getPPCPApplePaySessionChecked, true);
 const formatApplePayContactToCheckoutAddressMock = mocked(formatApplePayContactToCheckoutAddress, true);
 const getPaymentRequestDisplayItemsMock = mocked(getPaymentRequestDisplayItems, true);
@@ -41,7 +48,10 @@ const getCurrencyMock = mocked(getCurrency, true);
 const getShippingMock = mocked(getShipping, true);
 const getApplicationStateMock = mocked(getApplicationState, true);
 const setTaxesMock = mocked(setTaxes, true);
+const estimateTaxesMock = mocked(estimateTaxes, true);
 const getShippingLinesMock = mocked(getShippingLines, true);
+const estimateShippingLinesMock = mocked(estimateShippingLines, true);
+const getOrderInitialDataMock = mocked(getOrderInitialData, true);
 
 describe('testing ppcpOnShippingContactSelectedApple function',() => {
     const successReturn = {...baseReturnObject, success: true};
@@ -76,28 +86,60 @@ describe('testing ppcpOnShippingContactSelectedApple function',() => {
         callShippingAddressEndpointMock.mockReturnValue(Promise.resolve(successReturn));
         formatApplePayContactToCheckoutAddressMock.mockReturnValue(addressesMock.shipping);
         getShippingLinesMock.mockReturnValue(Promise.resolve(successReturn));
+        estimateShippingLinesMock.mockReturnValue(Promise.resolve(successReturn));
         setTaxesMock.mockReturnValue(Promise.resolve(successReturn));
+        estimateTaxesMock.mockReturnValue(Promise.resolve(successReturn));
         getPaymentRequestDisplayItemsMock.mockReturnValueOnce(displayItemMock);
     });
 
-    test('call successfully',async () => {
+    test('call successfully with RSA disabled',async () => {
         const expectedCompleteParam = {
             newLineItems: displayItemMappedMock,
             newShippingMethods: shippingMethodsMock,
             newTotal: {amount: '100.00', label: 'Total'}
         };
+        orderInitialDataMock.general_settings.checkout_process.rsa_enabled = false;
+        getOrderInitialDataMock.mockReturnValue(orderInitialDataMock);
 
         await ppcpOnShippingContactSelectedApple(eventMock).then(() => {
             expect(getCurrencyMock).toBeCalledTimes(1);
             expect(getPPCPApplePaySessionCheckedMock).toBeCalledTimes(1);
             expect(formatApplePayContactToCheckoutAddressMock).toBeCalledTimes(1);
             expect(formatApplePayContactToCheckoutAddressMock).toBeCalledWith(addressContact);
+            expect(getOrderInitialDataMock).toBeCalledTimes(1);
             expect(callShippingAddressEndpointMock).toBeCalledTimes(1);
             expect(callShippingAddressEndpointMock).toBeCalledWith(addressesMock.shipping, false);
             expect(getShippingLinesMock).toBeCalledTimes(1);
             expect(getShippingLinesMock).toBeCalledWith(API_RETRY);
             expect(setTaxesMock).toBeCalledTimes(1);
             expect(setTaxesMock).toBeCalledWith(API_RETRY);
+            expect(getApplicationStateMock).toBeCalledTimes(1);
+            expect(getPaymentRequestDisplayItemsMock).toBeCalledTimes(1);
+            expect(getShippingMock).toBeCalledTimes(1);
+            expect(applePaySessionCompleteShippingContactSelection).toBeCalledTimes(1);
+            expect(applePaySessionCompleteShippingContactSelection).toBeCalledWith(expectedCompleteParam);
+        });
+    });
+
+    test('call successfully with RSA enabled',async () => {
+        const expectedCompleteParam = {
+            newLineItems: displayItemMappedMock,
+            newShippingMethods: shippingMethodsMock,
+            newTotal: {amount: '100.00', label: 'Total'}
+        };
+        orderInitialDataMock.general_settings.checkout_process.rsa_enabled = true;
+        getOrderInitialDataMock.mockReturnValue(orderInitialDataMock);
+
+        await ppcpOnShippingContactSelectedApple(eventMock).then(() => {
+            expect(getCurrencyMock).toBeCalledTimes(1);
+            expect(getPPCPApplePaySessionCheckedMock).toBeCalledTimes(1);
+            expect(formatApplePayContactToCheckoutAddressMock).toBeCalledTimes(1);
+            expect(formatApplePayContactToCheckoutAddressMock).toBeCalledWith(addressContact);
+            expect(getOrderInitialDataMock).toBeCalledTimes(1);
+            expect(estimateShippingLinesMock).toBeCalledTimes(1);
+            expect(estimateShippingLinesMock).toBeCalledWith(addressesMock.shipping, API_RETRY);
+            expect(estimateTaxesMock).toBeCalledTimes(1);
+            expect(estimateTaxesMock).toBeCalledWith(addressesMock.shipping, API_RETRY);
             expect(getApplicationStateMock).toBeCalledTimes(1);
             expect(getPaymentRequestDisplayItemsMock).toBeCalledTimes(1);
             expect(getShippingMock).toBeCalledTimes(1);
@@ -158,11 +200,16 @@ describe('testing ppcpOnShippingContactSelectedApple function',() => {
             province: '',
             province_code: '',
         };
+
+        orderInitialDataMock.general_settings.checkout_process.rsa_enabled = false;
+        getOrderInitialDataMock.mockReturnValue(orderInitialDataMock);
+
         await ppcpOnShippingContactSelectedApple(eventMockNew).then(() => {
             expect(getCurrencyMock).toBeCalledTimes(1);
             expect(getPPCPApplePaySessionCheckedMock).toBeCalledTimes(1);
             expect(formatApplePayContactToCheckoutAddressMock).toBeCalledTimes(1);
             expect(formatApplePayContactToCheckoutAddressMock).toBeCalledWith(addressContactWithEmptyFields);
+            expect(getOrderInitialDataMock).toBeCalledTimes(1);
             expect(callShippingAddressEndpointMock).toBeCalledTimes(1);
             expect(callShippingAddressEndpointMock).toBeCalledWith(expectedShipping, false);
             expect(getShippingLinesMock).toBeCalledTimes(1);
@@ -221,11 +268,15 @@ describe('testing ppcpOnShippingContactSelectedApple function',() => {
             newTotal: {amount: '100.00', label: 'Total'}
         };
 
+        orderInitialDataMock.general_settings.checkout_process.rsa_enabled = false;
+        getOrderInitialDataMock.mockReturnValue(orderInitialDataMock);
+
         await ppcpOnShippingContactSelectedApple(eventMock).then(() => {
             expect(getCurrencyMock).toBeCalledTimes(1);
             expect(getPPCPApplePaySessionCheckedMock).toBeCalledTimes(1);
             expect(formatApplePayContactToCheckoutAddressMock).toBeCalledTimes(1);
             expect(formatApplePayContactToCheckoutAddressMock).toBeCalledWith(addressContact);
+            expect(getOrderInitialDataMock).toBeCalledTimes(1);
             expect(callShippingAddressEndpointMock).toBeCalledTimes(1);
             expect(callShippingAddressEndpointMock).toBeCalledWith(addressesMock.shipping, false);
             expect(getShippingLinesMock).toBeCalledTimes(shippingLineTimes);

--- a/tests/paypal/ppcp_apple/ppcpOnShippingMethodSelectedApple.test.ts
+++ b/tests/paypal/ppcp_apple/ppcpOnShippingMethodSelectedApple.test.ts
@@ -12,10 +12,19 @@ import {
     getCurrency,
     getShipping,
     getShippingLines,
-    setTaxes
+    getOrderInitialData,
+    setTaxes,
+    estimateTaxes,
+    getShippingAddress
 } from '@boldcommerce/checkout-frontend-library';
 import ApplePayShippingMethodSelectedEvent = ApplePayJS.ApplePayShippingMethodSelectedEvent;
-import {applicationStateMock, currencyMock, shippingMock} from '@boldcommerce/checkout-frontend-library/lib/variables/mocks';
+import {
+    applicationStateMock,
+    currencyMock,
+    shippingMock,
+    shippingAddressMock,
+    orderInitialDataMock
+} from '@boldcommerce/checkout-frontend-library/lib/variables/mocks';
 
 jest.mock('src/paypal/managePaypalState');
 jest.mock('src/utils/getPaymentRequestDisplayItems');
@@ -23,8 +32,11 @@ jest.mock('@boldcommerce/checkout-frontend-library/lib/state/getCurrency');
 jest.mock('@boldcommerce/checkout-frontend-library/lib/state/getShipping');
 jest.mock('@boldcommerce/checkout-frontend-library/lib/state/getApplicationState');
 jest.mock('@boldcommerce/checkout-frontend-library/lib/taxes/setTaxes');
+jest.mock('@boldcommerce/checkout-frontend-library/lib/taxes/estimateTaxes');
 jest.mock('@boldcommerce/checkout-frontend-library/lib/shipping/getShippingLines');
 jest.mock('@boldcommerce/checkout-frontend-library/lib/shipping/changeShippingLine');
+jest.mock('@boldcommerce/checkout-frontend-library/lib/state/getShippingAddress');
+jest.mock('@boldcommerce/checkout-frontend-library/lib/state/getOrderInitialData');
 const getPPCPApplePaySessionCheckedMock = mocked(getPPCPApplePaySessionChecked, true);
 const getPaymentRequestDisplayItemsMock = mocked(getPaymentRequestDisplayItems, true);
 const changeShippingLineMock = mocked(changeShippingLine, true);
@@ -32,7 +44,10 @@ const getCurrencyMock = mocked(getCurrency, true);
 const getShippingMock = mocked(getShipping, true);
 const getApplicationStateMock = mocked(getApplicationState, true);
 const setTaxesMock = mocked(setTaxes, true);
+const estimateTaxesMock = mocked(estimateTaxes, true);
 const getShippingLinesMock = mocked(getShippingLines, true);
+const getShippingAddressMock = mocked(getShippingAddress, true);
+const getOrderInitialDataMock = mocked(getOrderInitialData, true);
 
 describe('testing ppcpOnShippingMethodSelectedApple function',() => {
     const successReturn = {...baseReturnObject, success: true};
@@ -56,29 +71,64 @@ describe('testing ppcpOnShippingMethodSelectedApple function',() => {
         getPPCPApplePaySessionCheckedMock.mockReturnValue(applePaySessionObj);
         getCurrencyMock.mockReturnValue(currencyMock);
         getShippingMock.mockReturnValue(shippingMock);
+        getShippingAddressMock.mockReturnValue(shippingAddressMock);
         getApplicationStateMock.mockReturnValue(applicationStateMock);
         changeShippingLineMock.mockReturnValue(Promise.resolve(successReturn));
         getShippingLinesMock.mockReturnValue(Promise.resolve(successReturn));
         setTaxesMock.mockReturnValue(Promise.resolve(successReturn));
+        estimateTaxesMock.mockReturnValue(Promise.resolve(successReturn));
         getPaymentRequestDisplayItemsMock.mockReturnValueOnce(displayItemMock);
     });
 
-    test('call successfully',async () => {
+    test('call successfully with RSA disabled',async () => {
         const expectedCompleteParam = {
             newLineItems: displayItemMappedMock,
             newTotal: {amount: '100.00', label: 'Total'}
         };
+        orderInitialDataMock.general_settings.checkout_process.rsa_enabled = false;
+        getOrderInitialDataMock.mockReturnValue(orderInitialDataMock);
 
         await ppcpOnShippingMethodSelectedApple(eventMock).then(() => {
             expect(getCurrencyMock).toBeCalledTimes(1);
             expect(getPPCPApplePaySessionCheckedMock).toBeCalledTimes(1);
             expect(getShippingMock).toBeCalledTimes(1);
+            expect(getShippingAddressMock).toBeCalledTimes(1);
+            expect(getOrderInitialDataMock).toBeCalledTimes(1);
             expect(changeShippingLineMock).toBeCalledTimes(1);
             expect(changeShippingLineMock).toBeCalledWith('test_select_shipping_line_id', API_RETRY);
             expect(getShippingLinesMock).toBeCalledTimes(1);
             expect(getShippingLinesMock).toBeCalledWith(API_RETRY);
             expect(setTaxesMock).toBeCalledTimes(1);
             expect(setTaxesMock).toBeCalledWith(API_RETRY);
+            expect(getApplicationStateMock).toBeCalledTimes(1);
+            expect(getPaymentRequestDisplayItemsMock).toBeCalledTimes(1);
+            expect(applePaySessionCompleteShippingMethodSelection).toBeCalledTimes(1);
+            expect(applePaySessionCompleteShippingMethodSelection).toBeCalledWith(expectedCompleteParam);
+
+        });
+    });
+
+    test('call successfully with RSA enabled',async () => {
+        const expectedCompleteParam = {
+            newLineItems: displayItemMappedMock,
+            newTotal: {amount: '100.00', label: 'Total'}
+        };
+        orderInitialDataMock.general_settings.checkout_process.rsa_enabled = true;
+        getOrderInitialDataMock.mockReturnValue(orderInitialDataMock);
+
+
+        await ppcpOnShippingMethodSelectedApple(eventMock).then(() => {
+            expect(getCurrencyMock).toBeCalledTimes(1);
+            expect(getPPCPApplePaySessionCheckedMock).toBeCalledTimes(1);
+            expect(getShippingMock).toBeCalledTimes(1);
+            expect(getShippingAddressMock).toBeCalledTimes(1);
+            expect(getOrderInitialDataMock).toBeCalledTimes(1);
+            expect(changeShippingLineMock).toBeCalledTimes(1);
+            expect(changeShippingLineMock).toBeCalledWith('test_select_shipping_line_id', API_RETRY);
+            expect(getShippingLinesMock).toBeCalledTimes(1);
+            expect(getShippingLinesMock).toBeCalledWith(API_RETRY);
+            expect(estimateTaxesMock).toBeCalledTimes(1);
+            expect(estimateTaxesMock).toBeCalledWith(shippingAddressMock, API_RETRY);
             expect(getApplicationStateMock).toBeCalledTimes(1);
             expect(getPaymentRequestDisplayItemsMock).toBeCalledTimes(1);
             expect(applePaySessionCompleteShippingMethodSelection).toBeCalledTimes(1);


### PR DESCRIPTION
* Added check for RSA being enabled
* when it is enabled use the estimate calls
* When not enabled use the old behaviour
* Tests updated