### PR TITLE
Upgrading Paypal express

### DIFF
--- a/src/paypal/paypalCreateOrder.ts
+++ b/src/paypal/paypalCreateOrder.ts
@@ -1,6 +1,3 @@
-import {CreateOrderActions, CreateOrderData} from '@paypal/paypal-js/types/components/buttons';
-import {CreateOrderRequestBody} from '@paypal/paypal-js/types/apis/orders';
-import {getPaypalOrder} from 'src/paypal';
 import {
     IApiSuccessResponse,
     IWalletPayCreateOrderRequest, IWalletPayCreateOrderResponse,

--- a/src/paypal/paypalCreateOrder.ts
+++ b/src/paypal/paypalCreateOrder.ts
@@ -1,8 +1,32 @@
 import {CreateOrderActions, CreateOrderData} from '@paypal/paypal-js/types/components/buttons';
 import {CreateOrderRequestBody} from '@paypal/paypal-js/types/apis/orders';
 import {getPaypalOrder} from 'src/paypal';
+import {
+    IApiSuccessResponse,
+    IWalletPayCreateOrderRequest, IWalletPayCreateOrderResponse,
+    walletPayCreateOrder
+} from '@boldcommerce/checkout-frontend-library';
+import {API_RETRY} from 'src/types';
+import {displayError} from 'src/actions';
 
-export async function paypalCreateOrder(data: CreateOrderData, actions: CreateOrderActions): Promise<string> {
-    const paypalOrder: CreateOrderRequestBody = getPaypalOrder();
-    return actions.order.create(paypalOrder);
+export async function paypalCreateOrder(): Promise<string> {
+
+    const payment: IWalletPayCreateOrderRequest = {
+        gateway_type: 'paypal',
+        payment_data: {
+            locale: navigator.language,
+            payment_type: 'paypal',
+        }
+    };
+
+    const paymentResult = await walletPayCreateOrder(payment, API_RETRY);
+    if(paymentResult.success) {
+        const {data} = paymentResult.response as IApiSuccessResponse;
+        const {payment_data} = data as IWalletPayCreateOrderResponse;
+        const orderId = payment_data.id as string;
+        return orderId;
+    } else {
+        displayError('There was an unknown error while loading the payment.', 'payment_gateway', 'unknown_error');
+        return '';
+    }
 }

--- a/src/paypal/paypalOnApprove.ts
+++ b/src/paypal/paypalOnApprove.ts
@@ -1,103 +1,52 @@
-import {OnApproveActions, OnApproveData} from '@paypal/paypal-js/types/components/buttons';
-import {OrderResponseBody, ShippingInfo} from '@paypal/paypal-js/types/apis/orders';
+import {OnApproveData} from '@paypal/paypal-js/types/components/buttons';
 import {
-    callBillingAddressEndpoint,
-    callGuestCustomerEndpoint,
-    callShippingAddressEndpoint,
-    getFirstAndLastName,
     getTotals,
-    isObjectEquals
 } from 'src/utils';
-import {formatPaypalToApiAddress} from 'src/paypal/formatPaypalToApiAddress';
 import {
     addPayment,
     getCurrency,
     IAddPaymentRequest,
-    setTaxes,
+    IWalletPayOnApproveRequest,
+    walletPayOnApprove,
 } from '@boldcommerce/checkout-frontend-library';
 import {API_RETRY} from 'src/types';
 import {getPaypalGatewayPublicId} from 'src/paypal/managePaypalState';
 import {orderProcessing, displayError} from 'src/actions';
 
-export async function paypalOnApprove(data: OnApproveData, actions: OnApproveActions): Promise<void> {
+export async function paypalOnApprove(data: OnApproveData): Promise<void> {
     const {iso_code: currencyCode} = getCurrency();
-    return actions.order?.get().then(async ({ id, payer, purchase_units }: OrderResponseBody) => {
 
-        // extract all shipping info
-        const { name, address: shippingAddress } = purchase_units[0].shipping as ShippingInfo;
-        const shippingNames = getFirstAndLastName(name?.full_name);
-
-        // extract all billing info
-        const {name: payerName, address: billingAddress} = payer;
-        const billingNames = {firstName: payerName?.given_name || '', lastName: payerName?.surname || ''};
-        const phone = payer.phone?.phone_number.national_number || '';
-        const email = payer.email_address || '';
-        const isBillingAddressFilled = (
-            !!billingAddress?.address_line_1
-            && !!billingAddress.admin_area_1
-            && !!billingAddress.admin_area_2
-            && !!billingAddress.country_code
-            && !!billingAddress.postal_code
-        );
-
-        // set customer
-        const customerResult = await callGuestCustomerEndpoint(billingNames.firstName, billingNames.lastName, email);
-        const success = customerResult.success;
-        if(!success){
-            displayError('There was an unknown error while validating your customer information.', 'generic', 'unknown_error');
-            return;
+    const body: IWalletPayOnApproveRequest = {
+        gateway_type: 'paypal',
+        payment_data: {
+            locale: navigator.language,
+            paypal_order_id: data.orderID
         }
+    };
 
-        // check if shipping and billing are the same
-        const isSameNames = isObjectEquals(shippingNames, billingNames);
-        const isSameAddress = isBillingAddressFilled && isObjectEquals(shippingAddress, billingAddress);
-        const isBillingSame = isSameNames && isSameAddress;
-        const formattedShippingAddress = formatPaypalToApiAddress(shippingAddress, shippingNames.firstName, shippingNames.lastName, phone);
-        const formattedBillingAddress = formatPaypalToApiAddress(isBillingAddressFilled ? billingAddress : shippingAddress, billingNames.firstName, billingNames.lastName, phone);
+    const res = await walletPayOnApprove(body, API_RETRY);
 
-        // check and update shipping address
-        const shippingAddressResponse = await callShippingAddressEndpoint(formattedShippingAddress, true);
-        if(!shippingAddressResponse.success){
-            displayError('There was an unknown error while validating your shipping address.', 'shipping', 'unknown_error');
-            return;
-        }
+    if (!res.success) {
+        displayError('There was an unknown error while processing your payment.', 'payment_gateway', 'unknown_error');
+        return;
+    }
 
+    const totals = getTotals();
+    const payment: IAddPaymentRequest = {
+        token: `${data.orderID}:${data.payerID}`,
+        nonce: `${data.orderID}:${data.payerID}`, // TODO: Temporarily required - It is not in the API documentation, but required for Paypal Express
+        gateway_public_id: getPaypalGatewayPublicId(),
+        currency: currencyCode,
+        amount: totals.totalAmountDue,
+        wallet_pay_type: 'paypal',
+    } as IAddPaymentRequest;
+    const paymentResult = await addPayment(payment, API_RETRY);
+    if (!paymentResult.success) {
+        displayError('There was an unknown error while processing your payment.', 'payment_gateway', 'unknown_error');
+        return;
+    }
 
-        // check and update billing address
-        const billingAddressToSet = isBillingSame ? formattedShippingAddress : formattedBillingAddress;
-        const billingAddressResponse = await callBillingAddressEndpoint(billingAddressToSet, (!isBillingSame && isBillingAddressFilled));
-        if(!billingAddressResponse.success){
-            displayError('There was an unknown error while validating your billing address.', 'generic', 'unknown_error');
-            return;
-        }
+    // finalize order
+    orderProcessing();
 
-
-        // update taxes
-
-        const taxResponse = await setTaxes(API_RETRY);
-        if(!taxResponse.success){
-            displayError('There was an unknown error while calculating the taxes.', 'payment_gateway', 'no_tax');
-            return;
-        }
-
-
-        // add payment
-        const totals = getTotals();
-        const payment: IAddPaymentRequest = {
-            token: `${id}:${payer.payer_id}`,
-            nonce: `${id}:${payer.payer_id}`, // TODO: Temporarily required - It is not in the API documentation, but required for Paypal Express
-            gateway_public_id: getPaypalGatewayPublicId(),
-            currency: currencyCode,
-            amount: totals.totalAmountDue,
-            wallet_pay_type: 'paypal',
-        } as IAddPaymentRequest;
-        const paymentResult = await addPayment(payment, API_RETRY);
-        if(!paymentResult.success){
-            displayError('There was an unknown error while processing your payment.', 'payment_gateway', 'unknown_error');
-            return;
-        }
-
-        // finalize order
-        orderProcessing();
-    });
 }

--- a/src/paypal/paypalOnShippingChange.ts
+++ b/src/paypal/paypalOnShippingChange.ts
@@ -1,75 +1,24 @@
 import {OnShippingChangeActions, OnShippingChangeData} from '@paypal/paypal-js/types/components/buttons';
+import {API_RETRY,} from 'src';
 import {
-    getPaypalPatchOperations,
-    API_RETRY,
-    formatPaypalToApiAddress,
-    isSimilarStrings,
-    callShippingAddressEndpoint,
-    paypalConstants,
-    getPhoneNumber
-} from 'src';
-import {
-    changeShippingLine,
-    estimateShippingLines,
-    estimateTaxes,
-    getOrderInitialData,
-    getShipping,
-    getShippingLines,
-    setTaxes,
+    IWalletPayOnShippingRequest,
+    walletPayOnShipping,
 } from '@boldcommerce/checkout-frontend-library';
-import {OrderResponseBody, UpdateOrderRequestBody} from '@paypal/paypal-js/types/apis/orders';
+import {OrderResponseBody} from '@paypal/paypal-js/types/apis/orders';
 
 export async function paypalOnShippingChange(data: OnShippingChangeData, actions: OnShippingChangeActions): Promise<void|OrderResponseBody> {
-    const {shipping_address: address, selected_shipping_option: selectedOption} = data;
-    const {reject, order: {patch: patch}} = actions;
-    const {MAX_STRING_LENGTH: maxStringSize} = paypalConstants;
-    const {general_settings} = getOrderInitialData();
-    const rsaEnabled = general_settings.checkout_process.rsa_enabled;
-
-    if (address) {
-        const formattedAddress = formatPaypalToApiAddress(address, undefined, undefined , getPhoneNumber());
-        let success = false;
-        if (rsaEnabled) {
-            const shippingLinesResponse = await estimateShippingLines(formattedAddress, API_RETRY);
-            if (shippingLinesResponse.success) {
-                success = true;
-            }
-        } else {
-            const shippingAddressResponse = await callShippingAddressEndpoint(formattedAddress, false);
-            if (!shippingAddressResponse.success) {
-                return reject();
-            }
-            const shippingLinesResponse = await getShippingLines(API_RETRY);
-            if (shippingLinesResponse.success) {
-                success = true;
-            }
+    const body: IWalletPayOnShippingRequest = {
+        gateway_type: 'paypal',
+        payment_data: {
+            locale: navigator.language,
+            paypal_order_id: data.orderID,
+            shipping_address: data.shipping_address,
+            shipping_options: data.selected_shipping_option,
         }
+    };
 
-
-        if (success) {
-            const {selected_shipping: selectedShipping, available_shipping_lines: shippingLines} = getShipping();
-            if (selectedOption) {
-                const option = shippingLines.find(line => isSimilarStrings(line.description.substring(0, maxStringSize), selectedOption.label));
-                option && await changeShippingLine(option.id, API_RETRY);
-            } else if (!selectedShipping && shippingLines.length > 0) {
-                await changeShippingLine(shippingLines[0].id, API_RETRY);
-            }
-            await getShippingLines(API_RETRY);
-        }
+    const res = await walletPayOnShipping(body, API_RETRY);
+    if (!res.success) {
+        return actions.reject();
     }
-
-    let taxResponse;
-    if (rsaEnabled && address) {
-        const formattedAddress = formatPaypalToApiAddress(address, undefined, undefined , getPhoneNumber());
-        taxResponse = await estimateTaxes(formattedAddress, API_RETRY);
-    } else {
-        taxResponse = await setTaxes(API_RETRY);
-    }
-
-    if (taxResponse.success) {
-        const patchOperations = getPaypalPatchOperations(!!selectedOption);
-        return await patch(patchOperations as UpdateOrderRequestBody);
-    }
-
-    return reject();
 }

--- a/tests/paypal/paypalOnShippingChange.test.ts
+++ b/tests/paypal/paypalOnShippingChange.test.ts
@@ -1,103 +1,18 @@
 import {OnShippingChangeActions, OnShippingChangeData} from '@paypal/paypal-js/types/components/buttons';
-import {
-    API_RETRY,
-    callShippingAddressEndpoint,
-    formatPaypalToApiAddress,
-    getPaypalPatchOperations,
-    IPaypalPatchOperation,
-    paypalOnShippingChange
-} from 'src';
 import {mocked} from 'jest-mock';
 import {
     baseReturnObject,
-    changeShippingLine,
-    estimateShippingLines,
-    estimateTaxes,
-    getOrderInitialData,
-    getShipping,
-    getShippingLines,
-    IOrderInitialData,
-    ISetShippingAddressRequest,
-    IShipping
-} from '@boldcommerce/checkout-frontend-library';
-import {setTaxes} from '@boldcommerce/checkout-frontend-library/lib/taxes/setTaxes';
-import {orderInitialDataMock, shippingMock} from '@boldcommerce/checkout-frontend-library/lib/variables/mocks';
-import {AmountWithBreakdown, ShippingInfoOption} from '@paypal/paypal-js/types/apis/orders';
+    IWalletPayOnShippingResponse,
+    walletPayOnShipping,
 
-jest.mock('@boldcommerce/checkout-frontend-library/lib/state/getShipping');
-jest.mock('@boldcommerce/checkout-frontend-library/lib/shipping/getShippingLines');
-jest.mock('@boldcommerce/checkout-frontend-library/lib/shipping/changeShippingLine');
-jest.mock('@boldcommerce/checkout-frontend-library/lib/taxes/setTaxes');
-jest.mock('@boldcommerce/checkout-frontend-library/lib/address/setShippingAddress');
-jest.mock('@boldcommerce/checkout-frontend-library/lib/address/updateShippingAddress');
-jest.mock('@boldcommerce/checkout-frontend-library/lib/state/getOrderInitialData');
-jest.mock('@boldcommerce/checkout-frontend-library/lib/taxes/estimateTaxes');
-jest.mock('@boldcommerce/checkout-frontend-library/lib/shipping/estimateShippingLines');
-jest.mock('src/paypal/formatPaypalToApiAddress');
-jest.mock('src/paypal/getPaypalPatchOperations');
-jest.mock('src/utils/callShippingAddressEndpoint');
-const formatPaypalToApiAddressMock = mocked(formatPaypalToApiAddress, true);
-const getPaypalPatchOperationsMock = mocked(getPaypalPatchOperations, true);
-const getShippingMock = mocked(getShipping, true);
-const getShippingLinesMock = mocked(getShippingLines, true);
-const changeShippingLineMock = mocked(changeShippingLine, true);
-const setTaxesMock = mocked(setTaxes, true);
-const callShippingAddressEndpointMock = mocked(callShippingAddressEndpoint, true);
-const getOrderInitialDataMock = mocked(getOrderInitialData, true);
-const estimateShippingLinesMock = mocked(estimateShippingLines, true);
-const estimateTaxesMock = mocked(estimateTaxes, true);
+} from '@boldcommerce/checkout-frontend-library';
+import {applicationStateMock,} from '@boldcommerce/checkout-frontend-library/lib/variables/mocks';
+import {paypalOnShippingChange} from 'src';
+
+jest.mock('@boldcommerce/checkout-frontend-library/lib/walletPay/walletPayOnShipping');
+const walletPayOnShippingMock = mocked(walletPayOnShipping, true);
 
 describe('testing  paypalOnShippingChange function', () => {
-    const onShippingChangeActionsMock: OnShippingChangeActions = {
-        resolve: jest.fn().mockReturnValue(Promise.resolve()),
-        reject: jest.fn().mockReturnValue(Promise.resolve()),
-        order: {
-            patch: jest.fn().mockReturnValue(Promise.resolve({id: '123'}))
-        },
-    };
-    const formattedAddress: ISetShippingAddressRequest = {
-        address_line_1: '',
-        address_line_2: '',
-        business_name: '',
-        city: 'Winnipeg',
-        country: 'CA',
-        country_code: 'CA',
-        first_name: '',
-        last_name: '',
-        phone_number: '',
-        postal_code: 'R3Y0L6',
-        province: 'MB',
-        province_code: 'MB',
-    };
-    const paypalShippingOptions: Array<ShippingInfoOption> = [{
-        amount: {currency_code: 'CAD', value: '1.00'},
-        id: 'test_select_shipping_line_id',
-        label: 'Test Description',
-        selected: true,
-        type: 'SHIPPING'}];
-    const paypalAmountWithBreakdown: AmountWithBreakdown = {
-        breakdown: {
-            discount: {currency_code: 'CAD', value: '0.00'},
-            item_total: {currency_code: 'CAD', value: '0.00'},
-            shipping: {currency_code: 'CAD', value: '1.00'},
-            shipping_discount: {currency_code: 'CAD', value: '0.01'},
-            tax_total: {currency_code: 'CAD', value: '0.00'}
-        },
-        currency_code: 'CAD',
-        value: '0.00'
-    };
-    const paypalPatchOperations: Array<IPaypalPatchOperation> = [
-        {
-            op: 'replace',
-            path: '/purchase_units/@reference_id==\'default\'/amount',
-            value: paypalAmountWithBreakdown
-        },
-        {
-            op: 'replace',
-            path: '/purchase_units/@reference_id==\'default\'/shipping/options',
-            value: paypalShippingOptions
-        }
-    ];
     const dataMock: OnShippingChangeData = {
         forceRestAPI: true,
         shipping_address : {city: 'Winnipeg', state: 'MB', country_code: 'CA', postal_code: 'R3Y0L6'},
@@ -107,245 +22,46 @@ describe('testing  paypalOnShippingChange function', () => {
             amount: {currency_code: 'CAD', value: '1.00'}
         },
     };
-    const successfulReturnObject = {...baseReturnObject, success: true};
+
+    const actionMock: OnShippingChangeActions = {
+        resolve: jest.fn().mockReturnValue(Promise.resolve()),
+        reject: jest.fn().mockReturnValue(Promise.resolve()),
+        order: {
+            patch: jest.fn().mockReturnValue(Promise.resolve({id: '123'}))
+        },
+    };
 
     beforeEach(() => {
         jest.clearAllMocks();
-        formatPaypalToApiAddressMock.mockReturnValue(formattedAddress);
-        getPaypalPatchOperationsMock.mockReturnValue(paypalPatchOperations);
-        getShippingMock.mockReturnValue(shippingMock);
-        getShippingLinesMock.mockReturnValue(Promise.resolve(successfulReturnObject));
-        changeShippingLineMock.mockReturnValue(Promise.resolve(successfulReturnObject));
-        setTaxesMock.mockReturnValue(Promise.resolve(successfulReturnObject));
-        callShippingAddressEndpointMock.mockReturnValue(Promise.resolve(successfulReturnObject));
-        getOrderInitialDataMock.mockReturnValue(orderInitialDataMock);
-        estimateShippingLinesMock.mockReturnValue(Promise.resolve(successfulReturnObject));
-        estimateTaxesMock.mockReturnValue(Promise.resolve(successfulReturnObject));
     });
 
-    test('new addr, old addr empty, all data in and success API calls', async () => {
-        const result = await paypalOnShippingChange(dataMock, onShippingChangeActionsMock);
+    test('testing with successful call', async () => {
+        const response: IWalletPayOnShippingResponse = {
+            payment_data: {
+            },
+            application_state: applicationStateMock
+        };
 
-        expect(result).toStrictEqual({id: '123'});
-        expect(formatPaypalToApiAddressMock).toHaveBeenCalledTimes(1);
-        expect(formatPaypalToApiAddressMock).toHaveBeenCalledWith(dataMock.shipping_address, undefined, undefined , '');
-        expect(callShippingAddressEndpointMock).toHaveBeenCalledTimes(1);
-        expect(callShippingAddressEndpointMock).toHaveBeenCalledWith(formattedAddress, false);
-        expect(getShippingLinesMock).toHaveBeenCalledTimes(2);
-        expect(getShippingLinesMock).toHaveBeenCalledWith(API_RETRY);
-        expect(getShippingMock).toHaveBeenCalledTimes(1);
-        expect(changeShippingLineMock).toHaveBeenCalledTimes(0);
-        expect(setTaxesMock).toHaveBeenCalledTimes(1);
-        expect(getPaypalPatchOperationsMock).toHaveBeenCalledTimes(1);
-        expect(getPaypalPatchOperationsMock).toHaveBeenCalledWith(true);
-        expect(onShippingChangeActionsMock.reject).toHaveBeenCalledTimes(0);
-        expect(onShippingChangeActionsMock.order.patch).toHaveBeenCalledTimes(1);
+        const paymentReturn = {...baseReturnObject};
+        paymentReturn.success = true;
+        paymentReturn.response = {data: response};
+        walletPayOnShippingMock.mockReturnValue(Promise.resolve(paymentReturn));
+
+        await paypalOnShippingChange(dataMock, actionMock);
+        expect(walletPayOnShippingMock).toHaveBeenCalledTimes(1);
+        expect(actionMock.reject).toHaveBeenCalledTimes(0);
     });
 
-    test('new addr, old addr empty, all data in and success API calls with rsa', async () => {
-        const {general_settings: generalSettings} = orderInitialDataMock;
-        const {checkout_process: checkoutProcess} = generalSettings;
-        const newGeneralSettings = {...generalSettings, checkout_process: {...checkoutProcess, rsa_enabled: true}};
-        const initialData: IOrderInitialData = {...orderInitialDataMock, general_settings: newGeneralSettings};
-        getOrderInitialDataMock.mockReturnValue(initialData);
 
-        const result = await paypalOnShippingChange(dataMock, onShippingChangeActionsMock);
+    test('testing with unsuccessful call', async () => {
+        const paymentReturn = {...baseReturnObject};
+        paymentReturn.success = false;
+        walletPayOnShippingMock.mockReturnValue(Promise.resolve(paymentReturn));
 
-        expect(result).toStrictEqual({id: '123'});
-        expect(formatPaypalToApiAddressMock).toHaveBeenCalledTimes(2);
-        expect(formatPaypalToApiAddressMock).toHaveBeenCalledWith(dataMock.shipping_address, undefined, undefined , '');
-        expect(callShippingAddressEndpointMock).toHaveBeenCalledTimes(0);
-        expect(estimateShippingLinesMock).toHaveBeenCalledTimes(1);
-        expect(estimateShippingLinesMock).toHaveBeenCalledWith(formattedAddress, API_RETRY);
-        expect(getShippingLinesMock).toHaveBeenCalledTimes(1);
-        expect(getShippingLinesMock).toHaveBeenCalledWith(API_RETRY);
-        expect(getShippingMock).toHaveBeenCalledTimes(1);
-        expect(changeShippingLineMock).toHaveBeenCalledTimes(0);
-        expect(setTaxesMock).toHaveBeenCalledTimes(0);
-        expect(estimateTaxesMock).toHaveBeenCalledTimes(1);
-        expect(estimateTaxesMock).toHaveBeenCalledWith(formattedAddress, API_RETRY);
-        expect(getPaypalPatchOperationsMock).toHaveBeenCalledTimes(1);
-        expect(getPaypalPatchOperationsMock).toHaveBeenCalledWith(true);
-        expect(onShippingChangeActionsMock.reject).toHaveBeenCalledTimes(0);
-        expect(onShippingChangeActionsMock.order.patch).toHaveBeenCalledTimes(1);
+        await paypalOnShippingChange(dataMock, actionMock);
+        expect(walletPayOnShippingMock).toHaveBeenCalledTimes(1);
+        expect(actionMock.reject).toHaveBeenCalledTimes(1);
     });
 
-    test('no addr, no selected option and success API calls', async () => {
-        const data = {...dataMock, shipping_address: undefined, selected_shipping_option: undefined};
-
-        const result = await paypalOnShippingChange(data, onShippingChangeActionsMock);
-
-        expect(result).toStrictEqual({id: '123'});
-        expect(formatPaypalToApiAddressMock).toHaveBeenCalledTimes(0);
-        expect(callShippingAddressEndpointMock).toHaveBeenCalledTimes(0);
-        expect(getShippingLinesMock).toHaveBeenCalledTimes(0);
-        expect(getShippingMock).toHaveBeenCalledTimes(0);
-        expect(changeShippingLineMock).toHaveBeenCalledTimes(0);
-        expect(setTaxesMock).toHaveBeenCalledTimes(1);
-        expect(getPaypalPatchOperationsMock).toHaveBeenCalledTimes(1);
-        expect(getPaypalPatchOperationsMock).toHaveBeenCalledWith(false);
-        expect(onShippingChangeActionsMock.reject).toHaveBeenCalledTimes(0);
-        expect(onShippingChangeActionsMock.order.patch).toHaveBeenCalledTimes(1);
-    });
-
-    test('addr null values, no selected option and address invalid', async () => {
-        const data = {...dataMock, shipping_address: {
-            city: null, state: null, country_code: null, postal_code: null
-        }, selected_shipping_option: undefined};
-        callShippingAddressEndpointMock.mockReturnValueOnce(Promise.resolve(baseReturnObject));
-
-        const result = await paypalOnShippingChange(data as unknown as OnShippingChangeData, onShippingChangeActionsMock);
-
-        expect(result).toBe(undefined);
-        expect(formatPaypalToApiAddressMock).toHaveBeenCalledTimes(1);
-        expect(callShippingAddressEndpointMock).toHaveBeenCalledTimes(1);
-        expect(callShippingAddressEndpointMock).toHaveBeenCalledWith(formattedAddress, false);
-        expect(getShippingLinesMock).toHaveBeenCalledTimes(0);
-        expect(getShippingMock).toHaveBeenCalledTimes(0);
-        expect(changeShippingLineMock).toHaveBeenCalledTimes(0);
-        expect(setTaxesMock).toHaveBeenCalledTimes(0);
-        expect(getPaypalPatchOperationsMock).toHaveBeenCalledTimes(0);
-        expect(onShippingChangeActionsMock.reject).toHaveBeenCalledTimes(1);
-        expect(onShippingChangeActionsMock.order.patch).toHaveBeenCalledTimes(0);
-    });
-
-    test('same addr, old addr not empty, all data in and success API calls', async () => {
-        const result = await paypalOnShippingChange(dataMock, onShippingChangeActionsMock);
-
-        expect(result).toStrictEqual({id: '123'});
-        expect(formatPaypalToApiAddressMock).toHaveBeenCalledTimes(1);
-        expect(formatPaypalToApiAddressMock).toHaveBeenCalledWith(dataMock.shipping_address, undefined, undefined , '');
-        expect(callShippingAddressEndpointMock).toHaveBeenCalledTimes(1);
-        expect(callShippingAddressEndpointMock).toHaveBeenCalledWith(formattedAddress, false);
-        expect(getShippingLinesMock).toHaveBeenCalledTimes(2);
-        expect(getShippingLinesMock).toHaveBeenCalledWith(API_RETRY);
-        expect(getShippingMock).toHaveBeenCalledTimes(1);
-        expect(changeShippingLineMock).toHaveBeenCalledTimes(0);
-        expect(setTaxesMock).toHaveBeenCalledTimes(1);
-        expect(getPaypalPatchOperationsMock).toHaveBeenCalledTimes(1);
-        expect(getPaypalPatchOperationsMock).toHaveBeenCalledWith(true);
-        expect(onShippingChangeActionsMock.reject).toHaveBeenCalledTimes(0);
-        expect(onShippingChangeActionsMock.order.patch).toHaveBeenCalledTimes(1);
-    });
-
-    test('new addr, old addr not empty, all data in and success API calls', async () => {
-        const result = await paypalOnShippingChange(dataMock, onShippingChangeActionsMock);
-
-        expect(result).toStrictEqual({id: '123'});
-        expect(formatPaypalToApiAddressMock).toHaveBeenCalledTimes(1);
-        expect(formatPaypalToApiAddressMock).toHaveBeenCalledWith(dataMock.shipping_address, undefined, undefined , '');
-        expect(callShippingAddressEndpointMock).toHaveBeenCalledTimes(1);
-        expect(callShippingAddressEndpointMock).toHaveBeenCalledWith(formattedAddress, false);
-        expect(getShippingLinesMock).toHaveBeenCalledTimes(2);
-        expect(getShippingLinesMock).toHaveBeenCalledWith(API_RETRY);
-        expect(getShippingMock).toHaveBeenCalledTimes(1);
-        expect(changeShippingLineMock).toHaveBeenCalledTimes(0);
-        expect(setTaxesMock).toHaveBeenCalledTimes(1);
-        expect(getPaypalPatchOperationsMock).toHaveBeenCalledTimes(1);
-        expect(getPaypalPatchOperationsMock).toHaveBeenCalledWith(true);
-        expect(onShippingChangeActionsMock.reject).toHaveBeenCalledTimes(0);
-        expect(onShippingChangeActionsMock.order.patch).toHaveBeenCalledTimes(1);
-    });
-
-    test('same addr, old addr not empty, no selected line, no lines, and success API calls', async () => {
-        getShippingMock.mockReturnValueOnce(
-            {...shippingMock, selected_shipping: null, available_shipping_lines: []} as unknown as IShipping
-        );
-
-        const result = await paypalOnShippingChange(dataMock, onShippingChangeActionsMock);
-
-        expect(result).toStrictEqual({id: '123'});
-        expect(formatPaypalToApiAddressMock).toHaveBeenCalledTimes(1);
-        expect(formatPaypalToApiAddressMock).toHaveBeenCalledWith(dataMock.shipping_address, undefined, undefined , '');
-        expect(callShippingAddressEndpointMock).toHaveBeenCalledTimes(1);
-        expect(callShippingAddressEndpointMock).toHaveBeenCalledWith(formattedAddress, false);
-        expect(getShippingLinesMock).toHaveBeenCalledTimes(2);
-        expect(getShippingLinesMock).toHaveBeenCalledWith(API_RETRY);
-        expect(getShippingMock).toHaveBeenCalledTimes(1);
-        expect(changeShippingLineMock).toHaveBeenCalledTimes(0);
-        expect(setTaxesMock).toHaveBeenCalledTimes(1);
-        expect(getPaypalPatchOperationsMock).toHaveBeenCalledTimes(1);
-        expect(getPaypalPatchOperationsMock).toHaveBeenCalledWith(true);
-        expect(onShippingChangeActionsMock.reject).toHaveBeenCalledTimes(0);
-        expect(onShippingChangeActionsMock.order.patch).toHaveBeenCalledTimes(1);
-    });
-
-    test('same addr, old addr not empty, no selected line, with line matching selected option, and success API calls', async () => {
-        getShippingMock.mockReturnValueOnce(
-            {...shippingMock,
-                selected_shipping: null,
-                available_shipping_lines: [
-                    {id: '1', description: dataMock.selected_shipping_option?.label}
-                ]} as unknown as IShipping
-        );
-
-        const result = await paypalOnShippingChange(dataMock, onShippingChangeActionsMock);
-
-        expect(result).toStrictEqual({id: '123'});
-        expect(formatPaypalToApiAddressMock).toHaveBeenCalledTimes(1);
-        expect(formatPaypalToApiAddressMock).toHaveBeenCalledWith(dataMock.shipping_address, undefined, undefined , '');
-        expect(callShippingAddressEndpointMock).toHaveBeenCalledTimes(1);
-        expect(callShippingAddressEndpointMock).toHaveBeenCalledWith(formattedAddress, false);
-        expect(getShippingLinesMock).toHaveBeenCalledTimes(2);
-        expect(getShippingLinesMock).toHaveBeenCalledWith(API_RETRY);
-        expect(getShippingMock).toHaveBeenCalledTimes(1);
-        expect(changeShippingLineMock).toHaveBeenCalledTimes(1);
-        expect(changeShippingLineMock).toHaveBeenCalledWith('1', API_RETRY);
-        expect(setTaxesMock).toHaveBeenCalledTimes(1);
-        expect(getPaypalPatchOperationsMock).toHaveBeenCalledTimes(1);
-        expect(getPaypalPatchOperationsMock).toHaveBeenCalledWith(true);
-        expect(onShippingChangeActionsMock.reject).toHaveBeenCalledTimes(0);
-        expect(onShippingChangeActionsMock.order.patch).toHaveBeenCalledTimes(1);
-    });
-
-    test('same addr, old addr not empty, no selected option and line, and success API calls', async () => {
-        const data = {...dataMock, selected_shipping_option: undefined};
-        getShippingMock.mockReturnValueOnce(
-            {...shippingMock, selected_shipping: null} as unknown as IShipping
-        );
-
-        const result = await paypalOnShippingChange(data, onShippingChangeActionsMock);
-
-        expect(result).toStrictEqual({id: '123'});
-        expect(formatPaypalToApiAddressMock).toHaveBeenCalledTimes(1);
-        expect(formatPaypalToApiAddressMock).toHaveBeenCalledWith(dataMock.shipping_address, undefined, undefined , '');
-        expect(callShippingAddressEndpointMock).toHaveBeenCalledTimes(1);
-        expect(callShippingAddressEndpointMock).toHaveBeenCalledWith(formattedAddress, false);
-        expect(getShippingLinesMock).toHaveBeenCalledTimes(2);
-        expect(getShippingLinesMock).toHaveBeenCalledWith(API_RETRY);
-        expect(getShippingMock).toHaveBeenCalledTimes(1);
-        expect(changeShippingLineMock).toHaveBeenCalledTimes(1);
-        expect(changeShippingLineMock).toHaveBeenCalledWith('test_select_shipping_line_id', API_RETRY);
-        expect(setTaxesMock).toHaveBeenCalledTimes(1);
-        expect(getPaypalPatchOperationsMock).toHaveBeenCalledTimes(1);
-        expect(getPaypalPatchOperationsMock).toHaveBeenCalledWith(false);
-        expect(onShippingChangeActionsMock.reject).toHaveBeenCalledTimes(0);
-        expect(onShippingChangeActionsMock.order.patch).toHaveBeenCalledTimes(1);
-    });
-
-    test('same addr, old addr not empty, no selected option and line, and fail taxes API call', async () => {
-        const data = {...dataMock, selected_shipping_option: undefined};
-        getShippingMock.mockReturnValueOnce(
-            {...shippingMock, selected_shipping: null} as unknown as IShipping
-        );
-        setTaxesMock.mockReturnValueOnce(Promise.resolve(baseReturnObject));
-
-        const result = await paypalOnShippingChange(data, onShippingChangeActionsMock);
-
-        expect(result).toBe(undefined);
-        expect(formatPaypalToApiAddressMock).toHaveBeenCalledTimes(1);
-        expect(formatPaypalToApiAddressMock).toHaveBeenCalledWith(dataMock.shipping_address, undefined, undefined , '');
-        expect(callShippingAddressEndpointMock).toHaveBeenCalledTimes(1);
-        expect(callShippingAddressEndpointMock).toHaveBeenCalledWith(formattedAddress, false);
-        expect(getShippingLinesMock).toHaveBeenCalledTimes(2);
-        expect(getShippingLinesMock).toHaveBeenCalledWith(API_RETRY);
-        expect(getShippingMock).toHaveBeenCalledTimes(1);
-        expect(changeShippingLineMock).toHaveBeenCalledTimes(1);
-        expect(changeShippingLineMock).toHaveBeenCalledWith('test_select_shipping_line_id', API_RETRY);
-        expect(setTaxesMock).toHaveBeenCalledTimes(1);
-        expect(getPaypalPatchOperationsMock).toHaveBeenCalledTimes(0);
-        expect(onShippingChangeActionsMock.reject).toHaveBeenCalledTimes(1);
-        expect(onShippingChangeActionsMock.order.patch).toHaveBeenCalledTimes(0);
-    });
 
 });


### PR DESCRIPTION
Upgrading Paypal express from Client-side only integration to a Server-side integration.

1. Changing the paypal express orderCreate and onApprove functions.
2. Using [wallet pay endpoints](https://developer.boldcommerce.com/api/checkout#tag/Wallet-Pay) to move the implementation server side. 

More information about upgrading paypal is mentioned [here](https://github.com/paypal-examples/paypal-sdk-server-side-integration/blob/main/docs/update-from-client-side-helpers-to-server-side-for-partners.md).