### PR TITLE
PPCP Apple pay issue for UK address

### DIFF
--- a/src/paypal/ppcp_apple/ppcpOnPaymentAuthorizedApple.ts
+++ b/src/paypal/ppcp_apple/ppcpOnPaymentAuthorizedApple.ts
@@ -109,10 +109,10 @@ export async function ppcpOnPaymentAuthorizedApple(event: ApplePayPaymentAuthori
         const orderId = addedPayment.token;
 
         if (billingContact?.phoneNumber?.includes('+')) {
-            billingContact?.phoneNumber?.replace('+','');
+            billingContact.phoneNumber.replace('+','');
         }
         if (shippingContact?.phoneNumber?.includes('+')) {
-            shippingContact?.phoneNumber?.replace('+','');
+            shippingContact.phoneNumber.replace('+','');
         }
 
         await appleInstance.confirmOrder({orderId, token, billingContact, shippingContact});

--- a/src/paypal/ppcp_apple/ppcpOnPaymentAuthorizedApple.ts
+++ b/src/paypal/ppcp_apple/ppcpOnPaymentAuthorizedApple.ts
@@ -3,7 +3,6 @@ import {
     callBillingAddressEndpoint,
     callGuestCustomerEndpoint,
     callShippingAddressEndpoint,
-    isObjectEquals,
     orderProcessing,
     applePayConstants,
     getTotals,
@@ -36,7 +35,6 @@ export async function ppcpOnPaymentAuthorizedApple(event: ApplePayPaymentAuthori
 
     const shippingAddress = formatApplePayContactToCheckoutAddress(shippingContact as ApplePayPaymentContact);
     const billingAddress = formatApplePayContactToCheckoutAddress(billingContact as ApplePayPaymentContact);
-    const isSameAddress = isObjectEquals(shippingAddress, billingAddress);
 
     const fail = (error: ApplePayError) => {
         applePaySession.completePayment({
@@ -89,6 +87,7 @@ export async function ppcpOnPaymentAuthorizedApple(event: ApplePayPaymentAuthori
             gateway_public_id: gatewayPublicId,
             currency: currencyCode,
             amount: totalAmountDue,
+            wallet_pay_type: 'applepay',
             extra_payment_data: {
                 brand: token.paymentMethod.network,
                 last_digits: displayNameLast,

--- a/src/paypal/ppcp_apple/ppcpOnPaymentAuthorizedApple.ts
+++ b/src/paypal/ppcp_apple/ppcpOnPaymentAuthorizedApple.ts
@@ -61,7 +61,7 @@ export async function ppcpOnPaymentAuthorizedApple(event: ApplePayPaymentAuthori
         });
     }
 
-    const billingAddressResponse = await callBillingAddressEndpoint(billingAddress, !isSameAddress);
+    const billingAddressResponse = await callBillingAddressEndpoint(billingAddress, false);
     if (!billingAddressResponse.success) {
         return fail({
             code: applePayConstants.APPLEPAY_ERROR_CODE_BILLING_CONTACT,
@@ -89,7 +89,6 @@ export async function ppcpOnPaymentAuthorizedApple(event: ApplePayPaymentAuthori
             gateway_public_id: gatewayPublicId,
             currency: currencyCode,
             amount: totalAmountDue,
-            wallet_pay_type: 'applepay',
             extra_payment_data: {
                 brand: token.paymentMethod.network,
                 last_digits: displayNameLast,
@@ -109,6 +108,13 @@ export async function ppcpOnPaymentAuthorizedApple(event: ApplePayPaymentAuthori
         const successResponse = paymentResult.response as IApiSuccessResponse;
         const {payment: addedPayment} = successResponse.data as IAddPaymentResponse;
         const orderId = addedPayment.token;
+
+        if (billingContact?.phoneNumber?.includes('+')) {
+            billingContact?.phoneNumber?.replace('+','');
+        }
+        if (shippingContact?.phoneNumber?.includes('+')) {
+            shippingContact?.phoneNumber?.replace('+','');
+        }
 
         await appleInstance.confirmOrder({orderId, token, billingContact, shippingContact});
         applePaySession.completePayment(ApplePaySession.STATUS_SUCCESS);

--- a/tests/paypal/ppcp_apple/ppcpOnPaymentAuthorizedApple.test.ts
+++ b/tests/paypal/ppcp_apple/ppcpOnPaymentAuthorizedApple.test.ts
@@ -61,7 +61,7 @@ describe('testing ppcpOnPaymentAuthorizedApple function', () => {
     const addressContact: ApplePayPaymentContact = {
         givenName: 'John',
         familyName: 'Doe',
-        phoneNumber: '1231231234',
+        phoneNumber: '+1231231234',
         postalCode: 'R3Y0L6',
         locality: 'Winnipeg',
         addressLines: ['123 Any St', 'Line 2'],
@@ -153,8 +153,27 @@ describe('testing ppcpOnPaymentAuthorizedApple function', () => {
             givenName: '',
             familyName: '',
             emailAddress: '',
-            eventParam: {...event, payment: {...event.payment, shippingContact: undefined}}
+            eventParam: {...event, payment: {...event.payment, shippingContact: undefined, billingContact: undefined}}
         },
+        {
+            n: 'called successfully with same addresses with + phone number',
+            shipping: addressesMock.shipping,
+            billing: addressesMock.shipping,
+            givenName: addressContact.givenName,
+            familyName: addressContact.familyName,
+            emailAddress: addressContact.emailAddress,
+            eventParam: {...event, payment: {...event.payment, billingContact: {...addressContact, phoneNumber: '+1231231234'}, shippingContact: {...addressContact, phoneNumber: '+1231231234'}}}
+        },
+        {
+            n: 'called successfully with same addresses with undefined phone number',
+            shipping: addressesMock.shipping,
+            billing: addressesMock.shipping,
+            givenName: addressContact.givenName,
+            familyName: addressContact.familyName,
+            emailAddress: addressContact.emailAddress,
+            eventParam: {...event, payment: {...event.payment, billingContact: {...addressContact, phoneNumber: undefined}, shippingContact: {...addressContact, phoneNumber: undefined}}}
+        },
+
     ];
 
     test.each(happyPathData)('$n', async (

--- a/tests/paypal/ppcp_apple/ppcpOnPaymentAuthorizedApple.test.ts
+++ b/tests/paypal/ppcp_apple/ppcpOnPaymentAuthorizedApple.test.ts
@@ -135,7 +135,6 @@ describe('testing ppcpOnPaymentAuthorizedApple function', () => {
             givenName: addressContact.givenName,
             familyName: addressContact.familyName,
             emailAddress: addressContact.emailAddress,
-            notSame: true,
             eventParam: event
         },
         {
@@ -145,7 +144,6 @@ describe('testing ppcpOnPaymentAuthorizedApple function', () => {
             givenName: addressContact.givenName,
             familyName: addressContact.familyName,
             emailAddress: addressContact.emailAddress,
-            notSame: false,
             eventParam: {...event, payment: {...event.payment, billingContact: addressContact}}
         },
         {
@@ -155,7 +153,6 @@ describe('testing ppcpOnPaymentAuthorizedApple function', () => {
             givenName: '',
             familyName: '',
             emailAddress: '',
-            notSame: true,
             eventParam: {...event, payment: {...event.payment, shippingContact: undefined}}
         },
     ];
@@ -167,7 +164,6 @@ describe('testing ppcpOnPaymentAuthorizedApple function', () => {
             givenName,
             familyName,
             emailAddress,
-            notSame,
             eventParam }
     ) => {
         formatApplePayContactToCheckoutAddressMock
@@ -199,7 +195,7 @@ describe('testing ppcpOnPaymentAuthorizedApple function', () => {
         expect(callShippingAddressEndpointMock).toBeCalledTimes(1);
         expect(callShippingAddressEndpointMock).toBeCalledWith(shipping, true);
         expect(callBillingAddressEndpointMock).toBeCalledTimes(1);
-        expect(callBillingAddressEndpointMock).toBeCalledWith(billing, notSame);
+        expect(callBillingAddressEndpointMock).toBeCalledWith(billing, false);
         expect(setTaxesMock).toBeCalledTimes(1);
         expect(setTaxesMock).toBeCalledWith(API_RETRY);
         expect(getPPCPAppleCredentialsCheckedMock).toBeCalledTimes(1);


### PR DESCRIPTION
Removing the validation on billing address and modifying the phone number field for UK merchants